### PR TITLE
implement naieve diffs for Cow<'_, _>

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -294,7 +294,7 @@ impl<'a> Diff for &'a str {
     }
 }
 
-impl<'a, T> Diff for Cow<'a, T>
+impl<T> Diff for Cow<'_, T>
 where
     T: ToOwned + PartialEq + ?Sized,
     <T as ToOwned>::Owned: Clone + Default,

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,12 +1,18 @@
 use super::utils::find_match;
 use super::*;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::hash::Hash;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::{
+    borrow::Borrow,
+    fmt::{Debug, Formatter, Result as FmtResult},
+};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+};
 
 impl Diff for bool {
     type Repr = Option<bool>;
@@ -280,6 +286,32 @@ impl<'a> Diff for &'a str {
     fn apply(&mut self, diff: &Self::Repr) {
         if let Some(diff) = diff {
             *self = diff
+        }
+    }
+
+    fn identity() -> Self {
+        Default::default()
+    }
+}
+
+impl<'a, T> Diff for Cow<'a, T>
+where
+    T: ToOwned + PartialEq + ?Sized,
+    <T as ToOwned>::Owned: Default,
+{
+    type Repr = Option<Cow<'a, T>>;
+
+    fn diff(&self, other: &Self) -> Self::Repr {
+        if self != other {
+            Some(other.clone())
+        } else {
+            None
+        }
+    }
+
+    fn apply(&mut self, diff: &Self::Repr) {
+        if let Some(diff) = diff {
+            *self = diff.clone()
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,12 @@
 use super::*;
 
-use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::path::PathBuf;
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
 
 fn identity_test<D: Diff + Debug + PartialEq>(s: D) {
     assert_eq!(D::identity().apply_new(&D::identity().diff(&s)), s);
@@ -41,6 +44,19 @@ fn test_char_string() {
         Some(String::from("asdf"))
     );
     assert_eq!(String::from("42").diff(&String::from("42")), None);
+}
+
+#[test]
+fn test_cow() {
+    // Cow<'_, str>
+    assert_eq!(
+        Cow::from("42").diff(&Cow::from("asdf")),
+        Some(Cow::from("asdf"))
+    );
+    assert_eq!(
+        Cow::from("42").diff(&Cow::from("42")),
+        None
+    );
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -51,12 +51,9 @@ fn test_cow() {
     // Cow<'_, str>
     assert_eq!(
         Cow::from("42").diff(&Cow::from("asdf")),
-        Some(Cow::from("asdf"))
+        Some("asdf".into())
     );
-    assert_eq!(
-        Cow::from("42").diff(&Cow::from("42")),
-        None
-    );
+    assert_eq!(Cow::from("42").diff(&Cow::from("42")), None);
 }
 
 #[test]


### PR DESCRIPTION
This makes ~~super Cow powers~~ things like `Cow<'_, str>` and `Cow<'_, std::path::Path>` `Diff`-able.